### PR TITLE
Wek fix service notifier service

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,7 +3,12 @@ All wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
 
 Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog].
 
-## [12.44.0]
+## [Unreleased]
+
+* Korrektur des ServiceNotifierServices, damit NewsfeedListener angelegt werden können.
+* Automatisches Anlegen eines Admins mit *allen* Rechten am Ende des Setups.
+
+## [12.44.0] - 2022-05-13
 
 * #305 Keytext-Spalte der xtcasUserPrivilege-Tabelle vergrößern.
 * Setup wieder durchfürbar machen.

--- a/servicenotifier/src/main/java/aero/minova/cas/servicenotifier/ServiceNotifierService.java
+++ b/servicenotifier/src/main/java/aero/minova/cas/servicenotifier/ServiceNotifierService.java
@@ -428,7 +428,7 @@ public class ServiceNotifierService {
 		Table viewTable = new Table();
 		viewTable.setName("xtcasCASServices");
 		viewTable.addColumn(new Column("KeyLong", DataType.INTEGER));
-		viewTable.addColumn(new Column("CASServiceName", DataType.STRING));
+		viewTable.addColumn(new Column("KeyText", DataType.STRING));
 
 		Row viewRow = new Row();
 		viewRow.addValue(null);
@@ -438,7 +438,7 @@ public class ServiceNotifierService {
 		try {
 			viewResult = securityService.unsecurelyGetIndexView(viewTable);
 		} catch (Exception e) {
-			logger.logError("Error while trying to access view xvcasCASServices!", e);
+			logger.logError("Error while trying to access view xtcasCASServices!", e);
 			throw new RuntimeException(e);
 		}
 		// Da die ServiceNamen eindeutig sein müssen, kann man beruhigt den ersten KeyLong zurückgeben, den man findet.

--- a/servicenotifier/src/main/java/aero/minova/cas/servicenotifier/ServiceNotifierService.java
+++ b/servicenotifier/src/main/java/aero/minova/cas/servicenotifier/ServiceNotifierService.java
@@ -154,14 +154,7 @@ public class ServiceNotifierService {
 
 		try {
 			// Für die Delete-Prozedur muss der KeyLong rausgefunden werden.
-			Value keyLong = findViewEntry(//
-					null, //
-					inputTable.getRows().get(0).getValues().get(0), //
-					null, //
-					inputTable.getRows().get(0).getValues().get(1), //
-					inputTable.getRows().get(0).getValues().get(2)//
-			)//
-					.getRows().get(0).getValues().get(0);
+			Value keyLong = findServiceEntry(serviceName);
 
 			Table unregisterSerivceTable = new Table();
 			unregisterSerivceTable.setName("xpcasDeleteCASService");
@@ -315,8 +308,7 @@ public class ServiceNotifierService {
 	public void registerNewsfeedListener(Table inputTable) {
 
 		// Key zum CASServiceName herausfinden.
-		Value serviceKey = findViewEntry(inputTable.getRows().get(0).getValues().get(0), null, null, null, null)//
-				.getRows().get(0).getValues().get(0);
+		Value serviceKey = findServiceEntry(inputTable.getRows().get(0).getValues().get(0).getStringValue());
 
 		Table registerNewsfeedTable = new Table();
 		registerNewsfeedTable.setName("xpcasInsertNewsfeedListener");
@@ -419,6 +411,41 @@ public class ServiceNotifierService {
 		} catch (Exception e) {
 			logger.logError("Error while trying to initialize newsfeed!", e);
 			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Findet den KeyLong zu einem bestimmten CASServiceName heraus. Sucht dafür in der xtcasCASServices-Tabelle. Muss man statt findViewEntry verwenden, wenn
+	 * der ServiceKey zum Registrieren benötigt wird.
+	 * 
+	 * @param casServiceName
+	 *            Der ServiceName, zu welchem man den KeyLong finden möchte.
+	 * @return Den passenden KeyLong zum casServiceName.
+	 */
+	private Value findServiceEntry(String casServiceName) {
+		Table viewResult = new Table();
+
+		Table viewTable = new Table();
+		viewTable.setName("xtcasCASServices");
+		viewTable.addColumn(new Column("KeyLong", DataType.INTEGER));
+		viewTable.addColumn(new Column("CASServiceName", DataType.STRING));
+
+		Row viewRow = new Row();
+		viewRow.addValue(null);
+		viewRow.addValue(new Value(casServiceName, null));
+
+		viewTable.addRow(viewRow);
+		try {
+			viewResult = securityService.unsecurelyGetIndexView(viewTable);
+		} catch (Exception e) {
+			logger.logError("Error while trying to access view xvcasCASServices!", e);
+			throw new RuntimeException(e);
+		}
+		// Da die ServiceNamen eindeutig sein müssen, kann man beruhigt den ersten KeyLong zurückgeben, den man findet.
+		if (viewResult.getRows().size() <= 0) {
+			throw new RuntimeException("No service with the name " + casServiceName + " registered.");
+		} else {
+			return viewResult.getRows().get(0).getValues().get(0);
 		}
 	}
 

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>aero.minova</groupId>
 			<artifactId>cas.service</artifactId>
-			<version>12.39.3</version>
+			<version>12.44.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/setup/src/main/java/aero/minova/cas/setup/SetupService.java
+++ b/setup/src/main/java/aero/minova/cas/setup/SetupService.java
@@ -69,7 +69,7 @@ public class SetupService {
 				, true);
 				svc.setupExtensions();
 				spc.setupExtensions();
-				// TODO nach dem nächsten Release spc.setupPrivileges() einfügen.
+				spc.setupPrivileges();
 				return new ResponseEntity(result, HttpStatus.ACCEPTED);
 			} catch (Exception e) {
 				throw new RuntimeException(e);

--- a/setup/src/main/java/aero/minova/cas/setup/SetupService.java
+++ b/setup/src/main/java/aero/minova/cas/setup/SetupService.java
@@ -69,6 +69,8 @@ public class SetupService {
 				, true);
 				svc.setupExtensions();
 				spc.setupExtensions();
+
+				// Diese Methode darf erst ganz zum Schluss ausgeführt werden, damit sichergestellt werden kann, dass der Admin tatsächlich ALLE Rechte bekommt.
 				spc.setupPrivileges();
 				return new ResponseEntity(result, HttpStatus.ACCEPTED);
 			} catch (Exception e) {


### PR DESCRIPTION
Ich hatte bei der erstmaligen Implementation nicht berücksichtigt, dass die Einträge in der xvcasCASServices View erst auftauchen, wenn denn schon was registriert ist.
Deswegen brauche ich die neue Methode, welche einfach nur zu einem Dienstnamen den dazugehörigen Key ermittelt.