### PR TITLE
SpringBoot 2.7.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,7 +8,7 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 um Passwörter zu hashen.
 * Einbinden des ServiceNotifierServices in den QueueService, damit Dienstextensions Listener registrieren können, ohne dass NullPointerExceptions geworfen werden.
 * Integration von SonarQube, OWASP Dependency-Check und JaCoCo in die CI-Pipeline
-* Update auf SpringBoot 2.6.7
+* Update auf SpringBoot 2.7.0: MS-SQL Dependency wurde von 9.x auf 10.x aktualisiert. Das heißt der Wert für `encrypt` ist nun per Default `true`. Siehe `support.adoc` und https://github.com/spring-projects/spring-boot/issues/31157
 
 ## [12.44.1] - 2022-05-19
 

--- a/doc/adoc/support.adoc
+++ b/doc/adoc/support.adoc
@@ -190,3 +190,30 @@ Die häufigste Exception. Tritt auf, wenn:
 ### URI is not absolute
 
 Tritt (bisher) nur auf, wenn die BIRT Extension mit dem CAS gestartet wird und in den application.properties keine URI zum dazugehörigen BIRT Service gesetzt wurde. 
+
+
+## SQLServerException: PKIX path building failed
+Ab SpringBoot 2.7.0 wird für die Verbindung zum MS-SQL eine verschlüsselte Verbindung aufgebaut. Das heißt der Wert für `encrypt` ist nun per Default `true` zuvor war er auf `false`. Siehe https://github.com/spring-projects/spring-boot/issues/31157
+
+=== Fehlermeldung
+```
+2022-05-25T12:24:36.384 Servlet.service() for servlet [dispatcherServlet] in context with path [/cas] threw exception [Request processing failed; nested exception is aero.minova.cas.api.domain.ProcedureException: java.lang.RuntimeException: com.microsoft.sqlserver.jdbc.SQLServerException: Der Treiber konnte keine sichere Verbindung mit SQL Server über die SSL (Secure Sockets Layer)-Verschlüsselung herstellen. Fehler: 'PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target'. ClientConnectionId:19cbae03-1613-493f-acd0-decc7f65f14f] with root cause
+sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
+	at java.base/sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:141)
+	at java.base/sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:126)
+	at java.base/java.security.cert.CertPathBuilder.build(CertPathBuilder.java:297)
+	at java.base/sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:434)
+	at java.base/sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:306)
+	at java.base/sun.security.validator.Validator.validate(Validator.java:264)
+	at java.base/sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:313)
+	at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:233)
+	at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:110)
+
+[...]
+```
+
+=== Lösung
+Bei der Konfiguration von `aero_minova_database_url` den Parameter `encrypt` auf `false` setzen, z.B.:
+```
+aero_minova_database_url=<jdbc:sqlserver://host.docker.internal;encrypt=false;databaseName=test>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>aero.minova</groupId>
         <artifactId>spring.maven.root</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
         <relativePath/>
     </parent>
 

--- a/service/doc/adoc/installation.dev.adoc
+++ b/service/doc/adoc/installation.dev.adoc
@@ -25,7 +25,7 @@ Folgendes ist eine häufig nützliche minimal Konfiguration:
 [source,properties]
 ```
 login_dataSource=admin
-aero_minova_database_url=<jdbc:sqlserver://host.docker.internal;databaseName=test>
+aero_minova_database_url=<jdbc:sqlserver://host.docker.internal;encrypt=false;databaseName=test>
 aero_minova_database_user_name=<Datenbank-Nutzer>
 aero_minova_database_user_password=<Passwort>
 logging_level_root=DEBUG
@@ -48,7 +48,7 @@ docker run \
     --name=localtest \
     --publish=8084:8084 \
     --env login_dataSource='admin' \
-    --env aero_minova_database_url='jdbc:sqlserver://host.docker.internal;databaseName=test' \
+    --env aero_minova_database_url='jdbc:sqlserver://host.docker.internal;encrypt=false;databaseName=test' \
     --env aero_minova_database_user_name='Nutzer' \
     --env aero_minova_database_user_password='Passwort' \
     --env logging_level_root=DEBUG \
@@ -85,7 +85,7 @@ docker run \
     --name=dev_cas3 \
     --publish=8084:8084 \
     --env login_dataSource='admin' \
-    --env aero_minova_database_url='jdbc:sqlserver://host.docker.internal;databaseName=test' \
+    --env aero_minova_database_url='jdbc:sqlserver://host.docker.internal;encrypt=false;databaseName=test' \
     --env aero_minova_database_user_name='Nutzer' \
     --env aero_minova_database_user_password='Passwort' \
     --env logging_level_root=DEBUG \
@@ -107,7 +107,7 @@ docker build --tag=dev_cas2 .
 docker run --name=dev_cas3 `
         --publish=8084:8084 `
         --env login_dataSource='admin' `
-        --env aero_minova_database_url='jdbc:sqlserver://host.docker.internal;databaseName=AFIS_GDN' `
+        --env aero_minova_database_url='jdbc:sqlserver://host.docker.internal;encrypt=false;databaseName=AFIS_GDN' `
         --env aero_minova_database_user_name='sa' `
         --env aero_minova_database_user_password='Minova+0' `
         --env logging_level_root=DEBUG `

--- a/service/doc/adoc/properties.adoc
+++ b/service/doc/adoc/properties.adoc
@@ -49,7 +49,7 @@ IMPORTANT: Falls eine Property in den application.properties verändert wird, *m
 
 * aero_minova_database_url
 
-** *Default*: `jdbc:sqlserver://localhost;databaseName=AFIS_HAM`
+** *Default*: `jdbc:sqlserver://localhost;encrypt=false;databaseName=AFIS_HAM`
 
 * aero_minova_database_user_name
 

--- a/service/src/main/java/aero/minova/cas/sql/SystemDatabase.java
+++ b/service/src/main/java/aero/minova/cas/sql/SystemDatabase.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class SystemDatabase {
-	@Value("${aero_minova_database_url:jdbc:sqlserver://localhost;databaseName=AFIS_HAM}")
+	@Value("${aero_minova_database_url:jdbc:sqlserver://localhost;encrypt=false;databaseName=AFIS_HAM}")
 	String connectionString;
 
 	@Value("${aero_minova_database_user_name:sa}")


### PR DESCRIPTION
Update auf SpringBoot 2.7.0: MS-SQL Dependency wurde von 9.x auf 10.x aktualisiert. Das heißt der Wert für `encrypt` ist nun per Default `true`. Siehe `support.adoc` und https://github.com/spring-projects/spring-boot/issues/31157