### PR TITLE
Better error codes for LDAP issues

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 * Korrektur xpcasDeleteAuthorities. Obwohl die Authority auf -1 gestellt wurde, hatte man trotzdem volle Rechte. Nun wird sie ganz gelöscht.
 * Neue Icons.
 * Update auf SpringBoot 2.7.5
+* LDAP: Raise a Active Directory-specific error code instead of a BadCredentialsException
 
 
 ## [12.54.3] -- 2022-09-30

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 * Korrektur xpcasDeleteAuthorities. Obwohl die Authority auf -1 gestellt wurde, hatte man trotzdem volle Rechte. Nun wird sie ganz gelöscht.
 * Neue Icons.
 * Update auf SpringBoot 2.7.5
-* LDAP: Raise a Active Directory-specific error code instead of a BadCredentialsException
+* LDAP: Raise an Active Directory-specific error code instead of a BadCredentialsException
 
 
 ## [12.54.3] -- 2022-09-30

--- a/service/src/main/java/aero/minova/cas/SecurityConfig.java
+++ b/service/src/main/java/aero/minova/cas/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
 		if (dataSource.equals("ldap")) {
 			ActiveDirectoryLdapAuthenticationProvider acldap = new ActiveDirectoryLdapAuthenticationProvider(domain,
 					ldapServerAddress);
+			acldap.setConvertSubErrorCodesToExceptions(true);
 			acldap.setUserDetailsContextMapper(this.userDetailsContextMapper());
 			auth.authenticationProvider(acldap);
 		} else if (dataSource.equals("database")) {


### PR DESCRIPTION
See: https://docs.spring.io/spring-security/site/docs/3.1.x/reference/springsecurity-single.html#ldap-active-directory
```
Active Directory Error Codes

By default, a failed result will cause a standard Spring Security BadCredentialsException. If you set the 
property convertSubErrorCodesToExceptions to true, the exception messages will be parsed to attempt 
to extract the Active Directory-specific error code and raise a more specific exception. Check the class 
Javadoc for more information.
```
https://github.com/minova-afis/com.minova.min.swb/issues/6