### PR TITLE
DataSourceAutoConfiguration NICHT ausschließen

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,7 @@ All wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
 Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog].
 
 ## [UNRELEASED] -- XXXX-XX-XX
-
+* `@SpringBootApplication` Annotation OHNE `exclude = { DataSourceAutoConfiguration.class }`, damit automatisch eine `entityManagerFactory` erstellt wird.
 
 ## [12.56.2] -- 2023-01-10
 * Tabellen um Hilfsmethoden erweitert, mit der leichter auf Values zugegriffen werden kann

--- a/service/src/main/java/aero/minova/cas/CoreApplicationSystemApplication.java
+++ b/service/src/main/java/aero/minova/cas/CoreApplicationSystemApplication.java
@@ -5,13 +5,12 @@ import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(exclude = { DataSourceAutoConfiguration.class })
+@SpringBootApplication
 @ComponentScan({ "aero.minova", "com.minova" })
 @EntityScan({ "aero.minova", "com.minova" })
 @EnableJpaRepositories({ "aero.minova", "com.minova" })


### PR DESCRIPTION
Damit eine Extension über JPA auf eine Postgres-Datenbank zugreifen kann.

Mit der Konfiguration erscheint der Fehler:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Field movementRepository in com.minova.oiltanking.emergencyoperation.extension.EmergencyController required a bean named 'entityManagerFactory' that could not be found.

The injection point has the following annotations:
	- @org.springframework.beans.factory.annotation.Autowired(required=true)


Action:

Consider defining a bean named 'entityManagerFactory' in your configuration.
```