### PR TITLE
scr: dependency updates

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>3.0.1</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -106,17 +106,17 @@
 				<dependency>
 					<groupId>org.apache.cxf</groupId>
 					<artifactId>cxf-rt-frontend-jaxws</artifactId>
-					<version>3.5.5</version>
+					<version>4.0.0</version>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.cxf</groupId>
 					<artifactId>cxf-rt-transports-http</artifactId>
-					<version>3.5.5</version>
+					<version>4.0.0</version>
 				</dependency>
 				<dependency>
 					<groupId>jakarta.activation</groupId>
 					<artifactId>jakarta.activation-api</artifactId>
-					<version>2.1.0</version>
+					<version>2.1.1</version>
 				</dependency>
 			</dependencies>
 		</profile>


### PR DESCRIPTION
Manuell von Minova Mitarbeiter angetriggerte CI-Pipeline eines von Dependabot erstellten PR scheint nun auch Authentifizierungsprobleme zu haben, daher alle Dependency Updates als eigenes PR.

**Links:**
* https://sonarqube.minova.com/dashboard?branch=scr_dependency_updates&id=minova-afis_aero.minova.cas
* https://github.com/minova-afis/aero.minova.sam/issues/43
