### PR TITLE
scr: AWS dependency moved to be used as parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,19 @@
         <relativePath/>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Diese BOM wird für Erweiterungen (z.B. https://github.com/minova-afis/aero.minova.cas.plugin.attachments) bereitgestellt: service/doc/adoc/extensions.adoc -->
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.19.24</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <scm>
         <connection>scm:git:https://github.com/minova-afis/aero.minova.cas.git</connection>
         <developerConnection>scm:git:https://github.com/minova-afis/aero.minova.cas.git</developerConnection>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -16,19 +16,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!-- Diese BOM wird für Erweiterungen (z.B. https://github.com/minova-afis/aero.minova.cas.plugin.attachments) bereitgestellt: service/doc/adoc/extensions.adoc -->
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.19.24</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>aero.minova</groupId>
@@ -169,11 +156,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
-        </dependency>
-        <dependency>
-            <!-- Diese Abhängigkeit wird für Erweiterungen (z.B. https://github.com/minova-afis/aero.minova.cas.plugin.attachments) bereitgestellt: service/doc/adoc/extensions.adoc -->
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
2nd attempt: Change allows to reference `aero.minova:cas.parent`as parent-POM for extension projects, eg.:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>aero.minova</groupId>
    <artifactId>cas.plugin.attachments</artifactId>
    <version>12.4.0-SNAPSHOT</version>
    <description>OpenAPI: Sample server built with Spring Boot</description>
    <packaging>pom</packaging>
    <name>aero.minova.cas.plugin.attachments</name>

    <parent>
        <groupId>aero.minova</groupId>
        <artifactId>cas.parent</artifactId>
        <version>12.58.0-SNAPSHOT</version>
        <relativePath />
    </parent>
```

**Links:**
* https://sonarqube.minova.com/dashboard?branch=scr_awssdk_patch&id=minova-afis_aero.minova.cas
* https://github.com/minova-afis/aero.minova.sam/issues/43