### PR TITLE
CI-Pipeline Updates: `AdoptOpenJDK` wird zu `Eclipse Temurin`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,16 +20,16 @@ jobs:
     steps:
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v5.1
+        uses: tj-actions/branch-names@v6.4
 
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
           java-package: 'jdk'
           cache: 'maven'
@@ -39,7 +39,6 @@ jobs:
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
 
       - name: Maven build
         run: |
@@ -70,7 +69,7 @@ jobs:
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
 
       - name: Store report of Dependency Check
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dependency-check-report.html
           path: target/dependency-check-report.html

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           java-package: 'jdk'
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           java-package: 'jdk'
       - name: Build

--- a/.github/workflows/releaseAppAndHelper.yml
+++ b/.github/workflows/releaseAppAndHelper.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
           java-package: 'jdk'
           

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,15 +1,16 @@
 # Changelog
-All wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
+Alle wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
 
 Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog].
 
 ## [UNRELEASED] -- XXXX-XX-XX
-* #362 Zugriff auf weitere Datenbanken unterstzützen (zumindest über Views).
-* Property aero.minova.database.kind durch spring.jooq.sql-dialect ersetzt.
+* #362 Zugriff auf weitere Datenbanken unterstützen (zumindest über Views).
+* Property `aero.minova.database.kind` durch `spring.jooq.sql-dialect` ersetzt.
 * Proof of Concept Test für SQLViewController#getIndexView
 * Kopieren in MDI-Maske ermöglichen, um die Bedienung zu vereinfachen
 * Extension-Doku erweitern.
 * Prozedur xpcasInsertAllPrivilegesToUserGroup anpassen, sodass immer LastAction 1 beim Neueintragen von Privilegien gesetzt wird.
+* CI-Pipeline Updates: `AdoptOpenJDK` wird zu `Eclipse Temurin`
 
 
 ## [12.58.0] -- 2023-01-27

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>aero.minova</groupId>
         <artifactId>spring.maven.root</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.5</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
https://github.com/minova-afis/aero.minova.cas/issues/446