### PR TITLE
Eigentliche Fehlermeldung nutzen, um Nachvollziehbarkeit zu verbessern

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 * Korrektur der Connectionfreigabe.
 * AuthorizationTest ausbessern (Tabelle leeren, damit andere Tests nicht das Ergebnis beeinflussen)
 * `aero_minova_database_` properties entfernen (sind durch `spring.datasource.` abgedeckt)
+* Fehlermeldung bei Laden von Privilegien verbessern
 
 ## [12.59.1] -- 2023-04-04
 * Update auf SpringBoot 3.0.4.

--- a/service/src/main/java/aero/minova/cas/service/SecurityService.java
+++ b/service/src/main/java/aero/minova/cas/service/SecurityService.java
@@ -159,7 +159,7 @@ public class SecurityService {
 				SecurityContextHolder.getContext().setAuthentication(newAuth);
 			}
 		} catch (Exception e) {
-			throw new IllegalArgumentException("No User found, please login", e);
+			throw new IllegalArgumentException(e.getMessage(), e);
 		}
 
 	}


### PR DESCRIPTION
Auszug aus Log vorher:

```
2023-04-14T12:15:51.806 admin: CAS : Execute : INSERT INTO xtcasError (Username, ErrorMessage, Date) VALUES (?,?,?) with values: admin, No User found, please login, 2023-04-14 12:15:51.805598
```

Nachher:

```
2023-04-14T12:17:12.631 admin: CAS : Execute : INSERT INTO xtcasError (Username, ErrorMessage, Date) VALUES (?,?,?) with values: admin, org.postgresql.util.PSQLException: ERROR: permission denied for table xtcasusergroup, 2023-04-14 12:17:12.630859
```

Zweiteres gibt genauer eine Aussage darüber, was schiefgelaufen ist.

Außerdem stimmen so die Fehlermeldungen, die ans WFC geschickt werden, mit denen im Log überein.