### PR TITLE
AuthorizationController umbenennen und richtig einordnen

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 
 ## [UNRELEASED] -- XXXX-XX-XX
 * Update auf SpringBoot 3.0.6.
+* AuthorizationController zu AuthorizationService umbenennen, da es kein Controller ist.
 
 ## [12.60.1] -- 2023-04-27
 * Konfiguration der DataSource SpringBoot überlassen

--- a/app/src/main/app/postgresql/PostgresInfo.md
+++ b/app/src/main/app/postgresql/PostgresInfo.md
@@ -16,9 +16,9 @@ Option 1 (über SQL Skripte)
 5. Für jeden Privileg einen Eintrag in `xtcasLuUserPrivilegeUserGroup` erstellen, das Privileg mit der Gruppe verbindet
 
 Option 2 (JPA bzw. Controller im CAS, muss aus CAS-Extension aufgerufen werden)
-1. `AuthorizationController` über `@Autowired` laden
-2. Über `authorizationController.createUserPrivilege("privilegeName")` alle Privilegien erstellen
-3. Über `authorizationController.createAdminUser("username", "encryptedPassword")` einen Nutzer erstellen, der alle erstellten Berechtigungen besitzt 
+1. `AuthorizationService` über `@Autowired` laden
+2. Über `AuthorizationService.createUserPrivilege("privilegeName")` alle Privilegien erstellen
+3. Über `AuthorizationService.createAdminUser("username", "encryptedPassword")` einen Nutzer erstellen, der alle erstellten Berechtigungen besitzt 
 
 Dieser Code kann bei jedem Start aufgerufen werden.
 

--- a/service/src/main/java/aero/minova/cas/service/AuthorizationService.java
+++ b/service/src/main/java/aero/minova/cas/service/AuthorizationService.java
@@ -1,4 +1,4 @@
-package aero.minova.cas.controller;
+package aero.minova.cas.service;
 
 import java.util.Arrays;
 import java.util.List;
@@ -19,7 +19,7 @@ import aero.minova.cas.service.repository.UserPrivilegeRepository;
 import aero.minova.cas.service.repository.UsersRepository;
 
 @Controller
-public class AuthorizationController {
+public class AuthorizationService {
 
 	@Autowired
 	AuthoritiesRepository authoritiesRepository;

--- a/service/src/test/java/aero/minova/cas/controller/AuthorizationTest.java
+++ b/service/src/test/java/aero/minova/cas/controller/AuthorizationTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import aero.minova.cas.CoreApplicationSystemApplication;
+import aero.minova.cas.service.AuthorizationService;
 import aero.minova.cas.service.model.Authorities;
 import aero.minova.cas.service.model.LuUserPrivilegeUserGroup;
 import aero.minova.cas.service.model.UserGroup;
@@ -26,7 +27,7 @@ import aero.minova.cas.service.repository.UsersRepository;
 class AuthorizationTest {
 
 	@Autowired
-	AuthorizationController controller;
+	AuthorizationService controller;
 
 	@Autowired
 	AuthoritiesRepository authoritiesRepository;

--- a/service/src/test/java/aero/minova/cas/controller/SQLViewControllerTest.java
+++ b/service/src/test/java/aero/minova/cas/controller/SQLViewControllerTest.java
@@ -15,6 +15,7 @@ import aero.minova.cas.api.domain.Column;
 import aero.minova.cas.api.domain.DataType;
 import aero.minova.cas.api.domain.Row;
 import aero.minova.cas.api.domain.Table;
+import aero.minova.cas.service.AuthorizationService;
 
 @SpringBootTest(classes = CoreApplicationSystemApplication.class)
 @ActiveProfiles("test")
@@ -28,7 +29,7 @@ class SQLViewControllerTest {
 	SqlViewController testSubject;
 
 	@Autowired
-	AuthorizationController authorizationController;
+	AuthorizationService authorizationController;
 
 	@Test
 	@DisplayName("Methode getIndexView() testen")

--- a/service/src/test/java/aero/minova/cas/controller/SQLViewControllerTest.java
+++ b/service/src/test/java/aero/minova/cas/controller/SQLViewControllerTest.java
@@ -29,15 +29,15 @@ class SQLViewControllerTest {
 	SqlViewController testSubject;
 
 	@Autowired
-	AuthorizationService authorizationController;
+	AuthorizationService authorizationService;
 
 	@Test
 	@DisplayName("Methode getIndexView() testen")
 	void getIndexView() throws Exception {
 
 		// Recht und Admin-Nutzer erstellen
-		authorizationController.findOrCreateUserPrivilege("xvcasUserSecurity");
-		authorizationController.createOrUpdateAdminUser("admin", "$2a$10$l6uLtEVvQAOI7hOXutd7Ye0FtlaL7/npwGu/8YN31EhkHT0wjdtIq");
+		authorizationService.findOrCreateUserPrivilege("xvcasUserSecurity");
+		authorizationService.createOrUpdateAdminUser("admin", "$2a$10$l6uLtEVvQAOI7hOXutd7Ye0FtlaL7/npwGu/8YN31EhkHT0wjdtIq");
 
 		// Tabelle für Index-Anfrage erstellen
 		Table indexView = new Table();


### PR DESCRIPTION
Der AuthorizationController ist kein Controller.

Er ist ein @Service oder ein @Component.
Sein einziger Aufruf ist bisher im Projekt https://github.com/minova-afis/com.minova.oiltanking.emergencyoperation.

Das ist bisher noch nicht ausgeliefert, deswegen habe ich die Änderung ohne @Deprecated gewagt.