### PR TITLE
Helper-Version in Manifest an Helper-pom anpassen

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@ Alle wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
 Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog].
 
 ## [UNRELEASED] -- XXXX-XX-XX
+* Helper-Version in Manifest an Helper-pom anpassen
 
 ## [12.63.10] -- 2023-06-05
 * Helper-Manifest ausbessern

--- a/client/aero.minova.cas.app.helper/META-INF/MANIFEST.MF
+++ b/client/aero.minova.cas.app.helper/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: aero.minova.cas.app.helper
-Bundle-Version: 12.56.0.qualifier
+Bundle-Version: 12.63.10.qualifier
 Automatic-Module-Name: aero.minova.cas.app.helper
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Damit wird die Helper-Version im jar-Namen wieder korrekt aktualisiert