### PR TITLE
ServiceMessageReceiverLoginType Initialisierung über Java Code

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 
 ## [UNRELEASED] -- XXXX-XX-XX
 * xpcasInsertAllPrivilegesToUserGroup an neue Tabellenstrukturen anpassen, um Setup-Fehler zu beheben.
+* ServiceMessageReceiverLoginType Initialisierung über Java Code statt data.sql File durchführen. Damit funktioniert die Initialisierung, egal welche Datenbank verwendet wird
 
 ## [12.65.3] -- 2023-07-07
 * Login erweitern über Value aero.minova.cas.setup.logging.  

--- a/service/src/main/java/aero/minova/cas/servicenotifier/ServiceNotifierService.java
+++ b/service/src/main/java/aero/minova/cas/servicenotifier/ServiceNotifierService.java
@@ -65,6 +65,11 @@ public class ServiceNotifierService {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@PostConstruct
 	private void setup() {
+
+		findOrCreateServiceMessageReceiverLoginType("None");
+		findOrCreateServiceMessageReceiverLoginType("BasicAuth");
+		findOrCreateServiceMessageReceiverLoginType("OAuth2");
+
 		spc.registerExtension("xpcasRegisterService", inputTable -> {
 			try {
 				int keyLong = registerService(inputTable);

--- a/service/src/main/resources/data.sql
+++ b/service/src/main/resources/data.sql
@@ -1,3 +1,0 @@
-if not exists(select * from xtcasServiceMessageReceiverLoginType where KeyText = 'None') insert into xtcasServiceMessageReceiverLoginType (KeyText,LastAction,LastDate,LastUser) values ('None',1,GETDATE(),'cas')
-if not exists(select * from xtcasServiceMessageReceiverLoginType where KeyText = 'BasicAuth') insert into xtcasServiceMessageReceiverLoginType (KeyText,LastAction,LastDate,LastUser) values ('BasicAuth',1,GETDATE(),'cas')
-if not exists(select * from xtcasServiceMessageReceiverLoginType where KeyText = 'OAuth2') insert into xtcasServiceMessageReceiverLoginType (KeyText,LastAction,LastDate,LAstUser) values ('OAuth2',1,GETDATE(),'cas')

--- a/service/src/test/java/aero/minova/cas/service/ServiceNotifierServiceTest.java
+++ b/service/src/test/java/aero/minova/cas/service/ServiceNotifierServiceTest.java
@@ -1,0 +1,30 @@
+package aero.minova.cas.service;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import aero.minova.cas.CoreApplicationSystemApplication;
+import aero.minova.cas.service.repository.ServiceMessageReceiverLoginTypeRepository;
+import aero.minova.cas.servicenotifier.ServiceNotifierService;
+
+//benötigt, damit JUnit-Tests nicht abbrechen
+@SpringBootTest(classes = CoreApplicationSystemApplication.class, properties = { "application.runner.enabled=false" })
+class ServiceNotifierServiceTest {
+
+	@Autowired
+	ServiceNotifierService serviceNotifierService;
+
+	@Autowired
+	ServiceMessageReceiverLoginTypeRepository serviceMessageReceiverLoginTypeRepository;
+
+	@Test
+	void assureLoginTypesAreCreated() {
+		assertTrue(serviceMessageReceiverLoginTypeRepository.findByKeyText("None").isPresent());
+		assertTrue(serviceMessageReceiverLoginTypeRepository.findByKeyText("BasicAuth").isPresent());
+		assertTrue(serviceMessageReceiverLoginTypeRepository.findByKeyText("OAuth2").isPresent());
+	}
+
+}

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -9,8 +9,6 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.sql.init.mode=never
-
 
 server.port=8084
 


### PR DESCRIPTION
data.sql File entfernen. Damit funktioniert die Initialisierung, egal welche Datenbank verwendet wird.

closes #637