### PR TITLE
scr: added 3rd party dependencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,8 @@ Alle wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
 Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog].
 
 ## [UNRELEASED] -- XXXX-XX-XX
+* Update auf SpringBoot 3.1.3
+* jackson-datatype-jsr310, hibernate-jpamodelgen, commons-lang3 Abhängigkeiten für Erweiterungen bereitstellen.
 
 ## [12.65.17] -- 2023-08-21
 * Unique Key aus xtcasUserPrivilege entfernen, da es bei Azure Datenbanken zu Fehlern führt.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>aero.minova</groupId>
         <artifactId>spring.maven.root</artifactId>
-        <version>1.4.19</version>
+        <version>1.4.20</version>
         <relativePath />
     </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -209,9 +209,21 @@
 			<artifactId>tika-core</artifactId>
 			<version>2.8.0</version>
 		</dependency>
-
-
-
+		<dependency>
+			<!-- Diese Abhängigkeit wird für Erweiterungen (z.B. https://github.com/minova-afis/aero.minova.cas.plugin.sam) bereitgestellt: service/doc/adoc/extensions.adoc -->
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+		<dependency>
+			<!-- Diese Abhängigkeit wird für Erweiterungen (z.B. https://github.com/minova-afis/aero.minova.cas.plugin.sam) bereitgestellt: service/doc/adoc/extensions.adoc -->
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-jpamodelgen</artifactId>
+		</dependency>
+		<!-- Diese Abhängigkeit wird für Erweiterungen (z.B. https://github.com/minova-afis/aero.minova.cas.plugin.attachments) bereitgestellt: service/doc/adoc/extensions.adoc -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.h2database</groupId>


### PR DESCRIPTION
* SAM braucht für die Extensions `attachments` und `plugin` 3rd party libraries. Diese sollen bei `cas.service`hinterlegt werden.
   * Thema `jackson-datatype-jsr310`: OpenApi generiert "datetime" zur Java-Klasse `OffsetDateTime`, siehe https://www.baeldung.com/java-jackson-offsetdatetime
* Update auf SpringBoot 3.1.3

https://github.com/minova-afis/aero.minova.cas.plugin.attachments/pull/138