### PR TITLE
scr: added monitoring of Docker.io to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,9 @@ updates:
       interval: "daily"
     assignees:
       - "weber-minova"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "weber-minova"


### PR DESCRIPTION
*Dependabot* checks *Docker.io* for updates of the base image of the `Dockerfile`