### PR TITLE
JPA und BaseExtensions verbessern

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@ Alle wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
 Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog].
 
 ## Unreleased
+* LocalDateTime statt Timestamp in Entities verwenden
 
 [13.1.1] — 2024-02-02
 * Automatisches Einspielen von Postgres/H2 Views ausbessern

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 
 ## Unreleased
 * LocalDateTime statt Timestamp in Entities verwenden
+* Bei Index-Anfragen auch LastAction >0 filtern
 
 [13.1.1] — 2024-02-02
 * Automatisches Einspielen von Postgres/H2 Views ausbessern

--- a/app/src/main/app/sql/xvcasColumnSecurityIndex.sql
+++ b/app/src/main/app/sql/xvcasColumnSecurityIndex.sql
@@ -4,6 +4,7 @@ with encryption as
 			cs.KeyText,
 			cs.TableName,
 			cs.ColumnName,
-			cs.SecurityToken
+			cs.SecurityToken,
+			cs.LastAction
 	from xtcasColumnSecurity cs
 	where cs.LastAction > 0

--- a/app/src/main/app/sql/xvcasMdi.sql
+++ b/app/src/main/app/sql/xvcasMdi.sql
@@ -6,6 +6,7 @@ with encryption as
 			menu,
 			position,
 			securitytoken,
-			mdiTypeKey
+			mdiTypeKey,
+			LastAction
 	from xtcasMdi 
 	where LastAction > 0

--- a/app/src/main/app/sql/xvcasMdiIndex.sql
+++ b/app/src/main/app/sql/xvcasMdiIndex.sql
@@ -10,7 +10,8 @@ with encryption as
 			mt.KeyText as MdiTypeKeyText,
 			m.ModulName,
 			m.LastUser,
-			m.LastDate
+			m.LastDate,
+			m.LastAction
 	from xtcasMdi m
 	left join xtcasMdiType mt on m.MdiTypeKey = mt.KeyLong
 	where m.LastAction > 0

--- a/app/src/main/app/sql/xvcasServicePropertiesIndex.sql
+++ b/app/src/main/app/sql/xvcasServicePropertiesIndex.sql
@@ -4,6 +4,7 @@ with encryption as
            KeyText,
            Service,
            Property,
-           Val
+           Val,
+           LastAction
     from xtcasServiceProperties
     where LastAction > 0

--- a/app/src/main/app/sql/xvcasUserGroupIndex.sql
+++ b/app/src/main/app/sql/xvcasUserGroupIndex.sql
@@ -6,6 +6,7 @@ with encryption as
 			ug.Description,
 			ug.UserCode,
 			ug.SecurityToken,
-			ug.KeyLong as UserPrivilegeKey
+			ug.KeyLong as UserPrivilegeKey,
+			ug.LastAction
 	from xtcasUserGroup ug
 	where ug.LastAction > 0

--- a/app/src/main/app/sql/xvcasUserIndex.sql
+++ b/app/src/main/app/sql/xvcasUserIndex.sql
@@ -3,6 +3,7 @@ with encryption as
 	select	u.KeyLong,
 			u.KeyText,
 			u.UserSecurityToken,
-			u.Memberships
+			u.Memberships,
+			u.LastAction
 	from xtcasUser u
 	where u.LastAction > 0

--- a/app/src/main/app/sql/xvcasUserPrivilegeIndex.sql
+++ b/app/src/main/app/sql/xvcasUserPrivilegeIndex.sql
@@ -5,7 +5,8 @@ with encryption as
 			up.KeyText,
 			up.Description,
 			ug.KeyLong as UserGroupKey,
-			lu.RowLevelSecurity
+			lu.RowLevelSecurity,
+			up.LastAction
 	from xtcasUserPrivilege up
 	left outer join xtcasLuUserPrivilegeUserGroup lu on lu.UserPrivilegeKey = up.KeyLong
 	left outer join xtcasUserGroup ug on ug.KeyLong=lu.UserGroupKey

--- a/app/src/main/app/sql/xvcasUserPrivileges.sql
+++ b/app/src/main/app/sql/xvcasUserPrivileges.sql
@@ -3,7 +3,8 @@ with encryption as
 	select	up.KeyLong,
 			up.KeyText as PrivilegeKeyText,
 			ug.KeyText as KeyText,
-			upg.RowLevelSecurity
+			upg.RowLevelSecurity,
+			up.LastAction
 	from xtcasUserPrivilege up
 	inner join xtcasLuUserPrivilegeUserGroup upg on up.KeyLong = upg.UserPrivilegeKey and upg.LastAction > 0
 	inner join xtcasUserGroup ug on ug.KeyLong = upg.UserGroupKey and ug.LastAction > 0

--- a/app/src/main/app/sql/xvcasUserSecurity.sql
+++ b/app/src/main/app/sql/xvcasUserSecurity.sql
@@ -3,7 +3,8 @@ with encryption as
 	select	up.KeyLong,
 			up.KeyText as PrivilegeKeyText,
 			ug.SecurityToken,
-			upg.RowLevelSecurity
+			upg.RowLevelSecurity,
+			up.LastAction
 	from xtcasUserPrivilege up
 	inner join xtcasLuUserPrivilegeUserGroup upg on up.KeyLong = upg.UserPrivilegeKey and upg.LastAction > 0
 	inner join xtcasUserGroup ug on ug.KeyLong = upg.UserGroupKey and ug.LastAction > 0

--- a/app/src/main/app/sql/xvcasUsersIndex.sql
+++ b/app/src/main/app/sql/xvcasUsersIndex.sql
@@ -4,6 +4,7 @@ with encryption as
 			u.KeyText,
 			u.Username,
 			u.Description,
-			'XXXXX' as Password
+			'XXXXX' as Password,
+			u.LastAction
 	from xtcasUsers u
 	where u.LastAction > 0

--- a/app/src/main/java/aero/minova/cas/app/extension/AuthoritiesExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/AuthoritiesExtension.java
@@ -34,30 +34,25 @@ public class AuthoritiesExtension extends BaseGridExtension<Authorities> {
 
 	@Override
 	protected ResponseEntity<SqlProcedureResult> insertOrUpdate(Table inputTable) {
-		try {
 
-			List<Authorities> l = getEntitiesList(inputTable);
+		List<Authorities> l = getEntitiesList(inputTable);
 
-			for (Authorities entity : l) {
-				entity = fillAuthority(entity);
+		for (Authorities entity : l) {
+			entity = fillAuthority(entity);
 
-				service.save(entity);
-			}
-
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw handleError(e);
+			service.save(entity);
 		}
+
+		return ResponseEntityUtil.createResponseEntity(null, true);
+
 	}
 
 	@Override
 	public ResponseEntity<SqlProcedureResult> read(Table inputTable) {
-		try {
-			List<Authorities> findEntityById = ((AuthoritiesService) service).findByUsername(inputTable.getValue("Username", 0).getStringValue());
-			return ResponseEntityUtil.createResponseEntity(getResponseTable(findEntityById, inputTable.getName()), true);
-		} catch (Exception e) {
-			throw handleError(e);
-		}
+
+		List<Authorities> findEntityById = ((AuthoritiesService) service).findByUsername(inputTable.getValue("Username", 0).getStringValue());
+		return ResponseEntityUtil.createResponseEntity(getResponseTable(findEntityById, inputTable.getName()), true);
+
 	}
 
 	private Table getResponseTable(List<Authorities> authorities, String tableName) {

--- a/app/src/main/java/aero/minova/cas/app/extension/AuthoritiesExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/AuthoritiesExtension.java
@@ -29,6 +29,7 @@ public class AuthoritiesExtension extends BaseGridExtension<Authorities> {
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 

--- a/app/src/main/java/aero/minova/cas/app/extension/BaseExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/BaseExtension.java
@@ -80,60 +80,44 @@ public abstract class BaseExtension<E extends DataEntity> {
 	}
 
 	public ResponseEntity<SqlProcedureResult> insert(Table inputTable) {
-		try {
-			E entity = TABLE_CONVERSION_GSON.fromJson(TABLE_CONVERSION_GSON.toJsonTree(inputTable), entityClass);
 
-			E response = service.save(entity);
+		E entity = TABLE_CONVERSION_GSON.fromJson(TABLE_CONVERSION_GSON.toJsonTree(inputTable), entityClass);
 
-			JsonElement json = TABLE_CONVERSION_GSON.toJsonTree(response);
-			Table jsonTable = TABLE_CONVERSION_GSON.fromJson(json, Table.class);
-			Table resultTable = TableUtil.addDataTypeToTable(jsonTable, inputTable);
-			return ResponseEntityUtil.createResponseEntity(resultTable, false);
-		} catch (Exception e) {
-			throw handleError(e);
-		}
+		E response = service.save(entity);
+
+		JsonElement json = TABLE_CONVERSION_GSON.toJsonTree(response);
+		Table jsonTable = TABLE_CONVERSION_GSON.fromJson(json, Table.class);
+		Table resultTable = TableUtil.addDataTypeToTable(jsonTable, inputTable);
+		return ResponseEntityUtil.createResponseEntity(resultTable, false);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> update(Table inputTable) {
-		try {
-			E entity = TABLE_CONVERSION_GSON.fromJson(TABLE_CONVERSION_GSON.toJsonTree(inputTable), entityClass);
-			service.save(entity);
-			return ResponseEntityUtil.createResponseEntity(null, false);
-		} catch (Exception e) {
-			throw handleError(e);
-		}
+
+		E entity = TABLE_CONVERSION_GSON.fromJson(TABLE_CONVERSION_GSON.toJsonTree(inputTable), entityClass);
+		service.save(entity);
+		return ResponseEntityUtil.createResponseEntity(null, false);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> delete(Table inputTable) {
-		try {
 
-			service.deleteById(inputTable.getValue("KeyLong", 0).getIntegerValue());
+		service.deleteById(inputTable.getValue("KeyLong", 0).getIntegerValue());
 
-			return ResponseEntityUtil.createResponseEntity(null, false);
-		} catch (Exception e) {
-			throw handleError(e);
-		}
+		return ResponseEntityUtil.createResponseEntity(null, false);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> read(Table inputTable) {
-		try {
 
-			E findEntityById = service.findEntityById(inputTable.getValue("KeyLong", 0).getIntegerValue());
+		E findEntityById = service.findEntityById(inputTable.getValue("KeyLong", 0).getIntegerValue());
 
-			JsonElement json = TABLE_CONVERSION_GSON.toJsonTree(findEntityById);
-			Table jsonTable = TABLE_CONVERSION_GSON.fromJson(json, Table.class);
-			Table resultTable = TableUtil.addDataTypeToTable(jsonTable, inputTable);
-			logger.logger.info("Result: {}", resultTable);
-			return ResponseEntityUtil.createResponseEntity(resultTable, false);
-		} catch (Exception e) {
-			throw handleError(e);
-		}
-	}
+		JsonElement json = TABLE_CONVERSION_GSON.toJsonTree(findEntityById);
+		Table jsonTable = TABLE_CONVERSION_GSON.fromJson(json, Table.class);
+		Table resultTable = TableUtil.addDataTypeToTable(jsonTable, inputTable);
+		logger.logger.info("Result: {}", resultTable);
+		return ResponseEntityUtil.createResponseEntity(resultTable, false);
 
-	// TODO: Do anything fancy or remove
-	public static RuntimeException handleError(Exception e) {
-
-		return new RuntimeException(e);
 	}
 
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/BaseGridExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/BaseGridExtension.java
@@ -24,32 +24,26 @@ public abstract class BaseGridExtension<E extends DataEntity> extends BaseExtens
 	}
 
 	protected ResponseEntity<SqlProcedureResult> insertOrUpdate(Table inputTable) {
-		try {
 
-			List<E> l = getEntitiesList(inputTable);
+		List<E> l = getEntitiesList(inputTable);
 
-			for (E entity : l) {
-				service.save(entity);
-			}
-
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw handleError(e);
+		for (E entity : l) {
+			service.save(entity);
 		}
+
+		return ResponseEntityUtil.createResponseEntity(null, true);
+
 	}
 
 	@Override
 	public ResponseEntity<SqlProcedureResult> delete(Table inputTable) {
-		try {
 
-			for (Row r : inputTable.getRows()) {
-				service.deleteById(inputTable.getValue("KeyLong", r).getIntegerValue());
-			}
-
-			return ResponseEntityUtil.createResponseEntity(null, false);
-		} catch (Exception e) {
-			throw handleError(e);
+		for (Row r : inputTable.getRows()) {
+			service.deleteById(inputTable.getValue("KeyLong", r).getIntegerValue());
 		}
+
+		return ResponseEntityUtil.createResponseEntity(null, false);
+
 	}
 
 	protected List<E> getEntitiesList(Table inputTable) {

--- a/app/src/main/java/aero/minova/cas/app/extension/ColumnSecurityExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/ColumnSecurityExtension.java
@@ -12,6 +12,7 @@ public class ColumnSecurityExtension extends BaseExtension<ColumnSecurity> {
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/LuUserPrivilegeUserGroupExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/LuUserPrivilegeUserGroupExtension.java
@@ -23,6 +23,7 @@ public class LuUserPrivilegeUserGroupExtension extends BaseGridExtension<LuUserP
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 

--- a/app/src/main/java/aero/minova/cas/app/extension/LuUserPrivilegeUserGroupExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/LuUserPrivilegeUserGroupExtension.java
@@ -18,7 +18,7 @@ import jakarta.annotation.PostConstruct;
 
 @Component
 public class LuUserPrivilegeUserGroupExtension extends BaseGridExtension<LuUserPrivilegeUserGroup> {
-	
+
 	@PostConstruct
 	void setPrefix() {
 		viewPrefix = "xvcas";
@@ -28,19 +28,17 @@ public class LuUserPrivilegeUserGroupExtension extends BaseGridExtension<LuUserP
 
 	@Override
 	public ResponseEntity<SqlProcedureResult> read(Table inputTable) {
-		try {
-			List<LuUserPrivilegeUserGroup> lus;
 
-			if (inputTable.getValue("UserPrivilege.KeyLong", 0) != null) {
-				lus = ((LuUserPrivilegeUserGroupService) service).findByUserPrivilegeKey(inputTable.getValue("UserPrivilege.KeyLong", 0).getIntegerValue());
-			} else {
-				lus = ((LuUserPrivilegeUserGroupService) service).findByUserGroupKey(inputTable.getValue("UserGroup.KeyLong", 0).getIntegerValue());
-			}
+		List<LuUserPrivilegeUserGroup> lus;
 
-			return ResponseEntityUtil.createResponseEntity(getResponseTable(lus, inputTable.getName()), true);
-		} catch (Exception e) {
-			throw handleError(e);
+		if (inputTable.getValue("UserPrivilege.KeyLong", 0) != null) {
+			lus = ((LuUserPrivilegeUserGroupService) service).findByUserPrivilegeKey(inputTable.getValue("UserPrivilege.KeyLong", 0).getIntegerValue());
+		} else {
+			lus = ((LuUserPrivilegeUserGroupService) service).findByUserGroupKey(inputTable.getValue("UserGroup.KeyLong", 0).getIntegerValue());
 		}
+
+		return ResponseEntityUtil.createResponseEntity(getResponseTable(lus, inputTable.getName()), true);
+
 	}
 
 	private Table getResponseTable(List<LuUserPrivilegeUserGroup> lus, String tableName) {

--- a/app/src/main/java/aero/minova/cas/app/extension/MdiExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/MdiExtension.java
@@ -14,6 +14,7 @@ public class MdiExtension extends BaseExtension<Mdi> {
 
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/ServicePropertiesExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/ServicePropertiesExtension.java
@@ -12,6 +12,7 @@ public class ServicePropertiesExtension extends BaseExtension<ServiceProperties>
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/UserExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/UserExtension.java
@@ -12,6 +12,7 @@ public class UserExtension extends BaseExtension<User> {
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/UserGroupExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/UserGroupExtension.java
@@ -12,6 +12,7 @@ public class UserGroupExtension extends BaseExtension<UserGroup> {
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/UserGroupUserExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/UserGroupUserExtension.java
@@ -48,64 +48,50 @@ public class UserGroupUserExtension {
 	}
 
 	public ResponseEntity<SqlProcedureResult> insert(Table inputTable) {
-		try {
-			for (Row r : inputTable.getRows()) {
-				userService.addUserToUserGroup(//
-						inputTable.getValue("UserKey", r).getIntegerValue(), //
-						inputTable.getValue("KeyLong", r).getIntegerValue());
-			}
 
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
+		for (Row r : inputTable.getRows()) {
+			userService.addUserToUserGroup(//
+					inputTable.getValue("UserKey", r).getIntegerValue(), //
+					inputTable.getValue("KeyLong", r).getIntegerValue());
 		}
+
+		return ResponseEntityUtil.createResponseEntity(null, true);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> update(Table inputTable) {
-		try {
-			// Do Nothing, throw Exception??
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
-		}
+		// Can't update because we dont know the old value, so just do nothing
+		return ResponseEntityUtil.createResponseEntity(null, true);
 	}
 
 	public ResponseEntity<SqlProcedureResult> delete(Table inputTable) {
-		try {
-			for (Row r : inputTable.getRows()) {
-				userService.removeUserFromUserGroup(//
-						inputTable.getValue("UserKey", r).getIntegerValue(), //
-						inputTable.getValue("KeyLong", r).getIntegerValue());
-			}
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
+
+		for (Row r : inputTable.getRows()) {
+			userService.removeUserFromUserGroup(//
+					inputTable.getValue("UserKey", r).getIntegerValue(), //
+					inputTable.getValue("KeyLong", r).getIntegerValue());
 		}
+		return ResponseEntityUtil.createResponseEntity(null, true);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> read(Table inputTable) {
-		try {
 
-			int userGroupKey = inputTable.getValue("KeyLong", 0).getIntegerValue();
-			List<User> users = userService.findUsersInUserGroup(userGroupKey);
+		int userGroupKey = inputTable.getValue("KeyLong", 0).getIntegerValue();
+		List<User> users = userService.findUsersInUserGroup(userGroupKey);
 
-			Table res = new Table();
-			res.setName(inputTable.getName());
-			res.addColumn(new Column("KeyLong", DataType.INTEGER));
-			res.addColumn(new Column("UserKey", DataType.INTEGER));
+		Table res = new Table();
+		res.setName(inputTable.getName());
+		res.addColumn(new Column("KeyLong", DataType.INTEGER));
+		res.addColumn(new Column("UserKey", DataType.INTEGER));
 
-			for (User u : users) {
-				Row r = new Row();
-				r.addValue(new Value(userGroupKey));
-				r.addValue(new Value(u.getKeyLong()));
-				res.addRow(r);
-			}
-
-			return ResponseEntityUtil.createResponseEntity(res, true);
-
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
+		for (User u : users) {
+			Row r = new Row();
+			r.addValue(new Value(userGroupKey));
+			r.addValue(new Value(u.getKeyLong()));
+			res.addRow(r);
 		}
-	}
 
+		return ResponseEntityUtil.createResponseEntity(res, true);
+	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/UserGroupUsersExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/UserGroupUsersExtension.java
@@ -56,61 +56,51 @@ public class UserGroupUsersExtension {
 	}
 
 	public ResponseEntity<SqlProcedureResult> insert(Table inputTable) {
-		try {
-			for (Row r : inputTable.getRows()) {
-				usersService.addUserToUserGroup(//
-						inputTable.getValue("UsersKey", r).getIntegerValue(), //
-						inputTable.getValue("KeyLong", r).getIntegerValue());
-			}
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
+
+		for (Row r : inputTable.getRows()) {
+			usersService.addUserToUserGroup(//
+					inputTable.getValue("UsersKey", r).getIntegerValue(), //
+					inputTable.getValue("KeyLong", r).getIntegerValue());
 		}
+		return ResponseEntityUtil.createResponseEntity(null, true);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> update(Table inputTable) {
-		try {
-			// Do Nothing, throw Exception??
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
-		}
+
+		// Can't update because we dont know the old value, so just do nothing
+		return ResponseEntityUtil.createResponseEntity(null, true);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> delete(Table inputTable) {
-		try {
-			for (Row r : inputTable.getRows()) {
-				usersService.removeUserFromUserGroup(//
-						inputTable.getValue("UsersKey", r).getIntegerValue(), //
-						inputTable.getValue("KeyLong", r).getIntegerValue());
-			}
-			return ResponseEntityUtil.createResponseEntity(null, true);
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
+
+		for (Row r : inputTable.getRows()) {
+			usersService.removeUserFromUserGroup(//
+					inputTable.getValue("UsersKey", r).getIntegerValue(), //
+					inputTable.getValue("KeyLong", r).getIntegerValue());
 		}
+		return ResponseEntityUtil.createResponseEntity(null, true);
+
 	}
 
 	public ResponseEntity<SqlProcedureResult> read(Table inputTable) {
-		try {
 
-			int userGroupKey = inputTable.getValue("KeyLong", 0).getIntegerValue();
-			List<Users> users = usersService.findUsersInUserGroup(userGroupKey);
+		int userGroupKey = inputTable.getValue("KeyLong", 0).getIntegerValue();
+		List<Users> users = usersService.findUsersInUserGroup(userGroupKey);
 
-			Table res = new Table();
-			res.setName(inputTable.getName());
-			res.addColumn(new Column("KeyLong", DataType.INTEGER));
-			res.addColumn(new Column("UsersKey", DataType.INTEGER));
+		Table res = new Table();
+		res.setName(inputTable.getName());
+		res.addColumn(new Column("KeyLong", DataType.INTEGER));
+		res.addColumn(new Column("UsersKey", DataType.INTEGER));
 
-			for (Users u : users) {
-				Row r = new Row();
-				r.addValue(new Value(userGroupKey));
-				r.addValue(new Value(u.getKeyLong()));
-				res.addRow(r);
-			}
-
-			return ResponseEntityUtil.createResponseEntity(res, true);
-		} catch (Exception e) {
-			throw BaseExtension.handleError(e);
+		for (Users u : users) {
+			Row r = new Row();
+			r.addValue(new Value(userGroupKey));
+			r.addValue(new Value(u.getKeyLong()));
+			res.addRow(r);
 		}
+
+		return ResponseEntityUtil.createResponseEntity(res, true);
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/UserPrivilegeExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/UserPrivilegeExtension.java
@@ -12,6 +12,7 @@ public class UserPrivilegeExtension extends BaseExtension<UserPrivilege> {
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/UsersExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/UsersExtension.java
@@ -24,20 +24,16 @@ public class UsersExtension extends BaseExtension<Users> {
 
 	@Override
 	public ResponseEntity<SqlProcedureResult> read(Table inputTable) {
-		try {
+		Users findEntityById = service.findEntityById(inputTable.getValue("KeyLong", 0).getIntegerValue());
 
-			Users findEntityById = service.findEntityById(inputTable.getValue("KeyLong", 0).getIntegerValue());
+		// Passwort soll nicht ausgelesen werden
+		findEntityById.setPassword(null);
 
-			// Passwort soll nicht ausgelesen werden
-			findEntityById.setPassword(null);
+		JsonElement json = TABLE_CONVERSION_GSON.toJsonTree(findEntityById);
+		Table jsonTable = TABLE_CONVERSION_GSON.fromJson(json, Table.class);
+		Table resultTable = TableUtil.addDataTypeToTable(jsonTable, inputTable);
+		logger.logger.info("Result: {}", resultTable);
+		return ResponseEntityUtil.createResponseEntity(resultTable, false);
 
-			JsonElement json = TABLE_CONVERSION_GSON.toJsonTree(findEntityById);
-			Table jsonTable = TABLE_CONVERSION_GSON.fromJson(json, Table.class);
-			Table resultTable = TableUtil.addDataTypeToTable(jsonTable, inputTable);
-			logger.logger.info("Result: {}", resultTable);
-			return ResponseEntityUtil.createResponseEntity(resultTable, false);
-		} catch (Exception e) {
-			throw handleError(e);
-		}
 	}
 }

--- a/app/src/main/java/aero/minova/cas/app/extension/UsersExtension.java
+++ b/app/src/main/java/aero/minova/cas/app/extension/UsersExtension.java
@@ -19,6 +19,7 @@ public class UsersExtension extends BaseExtension<Users> {
 	void setPrefix() {
 		viewPrefix = "xvcas";
 		procedurePrefix = "xpcas";
+		tablePrefix = "xtcas";
 		super.basicSetup();
 	}
 

--- a/app/src/main/resources/postgres/xvcasColumnSecurityIndex.sql
+++ b/app/src/main/resources/postgres/xvcasColumnSecurityIndex.sql
@@ -4,7 +4,8 @@ as
 			cs.KeyText,
 			cs.TableName,
 			cs.ColumnName,
-			cs.SecurityToken
+			cs.SecurityToken,
+			cs.LastAction
 	from xtcasColumnSecurity cs
 	where cs.LastAction > 0
 	;

--- a/app/src/main/resources/postgres/xvcasMdiIndex.sql
+++ b/app/src/main/resources/postgres/xvcasMdiIndex.sql
@@ -10,7 +10,8 @@ CREATE OR REPLACE VIEW public.xvcasMdiIndex
 			mt.KeyText as MdiTypeKeyText,
 			m.ModulName,
 			m.LastUser,
-			m.LastDate
+			m.LastDate,
+			m.LastAction
 	from xtcasMdi m
 	left join xtcasMdiType mt on m.MdiTypeKey = mt.KeyLong
 	where m.LastAction > 0;

--- a/app/src/main/resources/postgres/xvcasServicePropertiesIndex.sql
+++ b/app/src/main/resources/postgres/xvcasServicePropertiesIndex.sql
@@ -4,6 +4,7 @@ as
            KeyText,
            Service,
            Property,
-           Val
+           Val,
+           LastAction
     from xtcasServiceProperties
     where LastAction > 0;

--- a/app/src/main/resources/postgres/xvcasUserGroupIndex.sql
+++ b/app/src/main/resources/postgres/xvcasUserGroupIndex.sql
@@ -6,6 +6,7 @@ as
 			ug.Description,
 			ug.UserCode,
 			ug.SecurityToken,
-			ug.KeyLong as UserPrivilegeKey
+			ug.KeyLong as UserPrivilegeKey,
+			ug.LastAction
 	from xtcasUserGroup ug
 	where ug.LastAction > 0;

--- a/app/src/main/resources/postgres/xvcasUserIndex.sql
+++ b/app/src/main/resources/postgres/xvcasUserIndex.sql
@@ -3,6 +3,7 @@ as
 	select	u.KeyLong,
 			u.KeyText,
 			u.UserSecurityToken,
-			u.Memberships
+			u.Memberships,
+			u.LastAction
 	from xtcasUser u
 	where u.LastAction > 0;

--- a/app/src/main/resources/postgres/xvcasUserIndex2.sql
+++ b/app/src/main/resources/postgres/xvcasUserIndex2.sql
@@ -6,6 +6,7 @@ CREATE OR REPLACE VIEW public.xvcasUserIndex2
 			u.Memberships,
 			u.LastAction,
 			u.LastDate,
-			u.LastUser
+			u.LastUser,
+			u.LastAction
 	from xtcasUser u
 	where u.LastAction > 0;

--- a/app/src/main/resources/postgres/xvcasUserPrivilegeIndex.sql
+++ b/app/src/main/resources/postgres/xvcasUserPrivilegeIndex.sql
@@ -5,7 +5,8 @@ as
 			up.KeyText,
 			up.Description,
 			ug.KeyLong as UserGroupKey,
-			lu.RowLevelSecurity
+			lu.RowLevelSecurity,
+			lu.LastAction
 	from xtcasUserPrivilege up
 	left outer join xtcasLuUserPrivilegeUserGroup lu on lu.UserPrivilegeKey = up.KeyLong
 	left outer join xtcasUserGroup ug on ug.KeyLong=lu.UserGroupKey

--- a/app/src/main/resources/postgres/xvcasUserSecurity.sql
+++ b/app/src/main/resources/postgres/xvcasUserSecurity.sql
@@ -3,7 +3,8 @@ AS
 SELECT up.KeyLong,
 			up.KeyText AS PrivilegeKeyText,
 			ug.SecurityToken,
-			upg.RowLevelSecurity
+			upg.RowLevelSecurity,
+			up.LastAction
 	FROM xtcasUserPrivilege up
 	INNER JOIN xtcasLuUserPrivilegeUserGroup upg ON up.KeyLong = upg.UserPrivilegeKey AND upg.LastAction > 0
 	INNER JOIN xtcasUserGroup ug ON ug.KeyLong = upg.UserGroupKey AND ug.LastAction > 0

--- a/app/src/main/resources/postgres/xvcasUsersIndex.sql
+++ b/app/src/main/resources/postgres/xvcasUsersIndex.sql
@@ -4,6 +4,7 @@ as
 			u.KeyText,
 			u.Username,
 			u.Description,
-			'XXXXX' as Password
+			'XXXXX' as Password,
+			u.LastAction
 	from xtcasUsers u
 	where u.LastAction > 0;

--- a/service/src/main/java/aero/minova/cas/controller/SqlViewController.java
+++ b/service/src/main/java/aero/minova/cas/controller/SqlViewController.java
@@ -102,12 +102,16 @@ public class SqlViewController {
 	@PostMapping(value = "data/index", produces = "application/json")
 	public Table getIndexView(@RequestBody Table inputTable) throws Exception {
 		customLogger.logUserRequest(": data/view: ", inputTable);
+		return getIndexView(inputTable, true);
+	}
+
+	public Table getIndexView(@RequestBody Table inputTable, boolean checkForExtension) throws Exception {
 		// Die Privilegien-Abfrage muss vor allem Anderen passieren. Falls das Privileg nicht vorhanden ist MUSS eine TableException geworfen werden.
 		List<Row> authoritiesForThisTable = securityService.getPrivilegePermissions(inputTable.getName());
 		if (authoritiesForThisTable.isEmpty()) {
 			throw new TableException(new RuntimeException("msg.PrivilegeError %" + inputTable.getName()));
 		}
-		if (extensions.containsKey(inputTable.getName())) {
+		if (checkForExtension && extensions.containsKey(inputTable.getName())) {
 			synchronized (extensionSynchronizer) {
 				return extensions.get(inputTable.getName()).apply(inputTable);
 			}

--- a/service/src/main/java/aero/minova/cas/service/BaseService.java
+++ b/service/src/main/java/aero/minova/cas/service/BaseService.java
@@ -1,7 +1,6 @@
 package aero.minova.cas.service;
 
-import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -62,7 +61,7 @@ public abstract class BaseService<E extends DataEntity> {
 			entity.setLastAction(2);
 		}
 
-		entity.setLastDate(Timestamp.from(Instant.now()));
+		entity.setLastDate(LocalDateTime.now());
 		entity.setLastUser(getCurrentUser());
 		entity = repository.save(entity);
 
@@ -80,7 +79,7 @@ public abstract class BaseService<E extends DataEntity> {
 
 		entity.setLastAction(-1);
 		entity.setLastUser(getCurrentUser());
-		entity.setLastDate(Timestamp.from(Instant.now()));
+		entity.setLastDate(LocalDateTime.now());
 		repository.save(entity);
 	}
 

--- a/service/src/main/java/aero/minova/cas/service/QueueService.java
+++ b/service/src/main/java/aero/minova/cas/service/QueueService.java
@@ -1,9 +1,9 @@
 package aero.minova.cas.service;
 
 import java.nio.charset.StandardCharsets;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
@@ -178,7 +178,7 @@ public class QueueService implements BiConsumer<Table, ResponseEntity<Object>> {
 				}
 
 				// Falls die Nachricht älter ist als das allowedMessageAge muss die Nachricht gelöscht werden.
-				if (pendingMessage.getMessageCreationDate().toInstant().isBefore(Instant.now().minus(allowedMessageAge, ChronoUnit.DAYS))) {
+				if (pendingMessage.getMessageCreationDate().toInstant(ZoneOffset.UTC).isBefore(Instant.now().minus(allowedMessageAge, ChronoUnit.DAYS))) {
 					deleteMessage(pendingMessage);
 					continue;
 				}
@@ -240,7 +240,7 @@ public class QueueService implements BiConsumer<Table, ResponseEntity<Object>> {
 				serviceMessage.setCasService(service);
 				serviceMessage.setMessage(message);
 
-				serviceMessage.setMessageCreationDate(Timestamp.valueOf(LocalDateTime.now()));
+				serviceMessage.setMessageCreationDate(LocalDateTime.now());
 
 				serviceMessageRepo.saveAndFlush(serviceMessage);
 

--- a/service/src/main/java/aero/minova/cas/service/model/Authorities.java
+++ b/service/src/main/java/aero/minova/cas/service/model/Authorities.java
@@ -1,6 +1,6 @@
 package aero.minova.cas.service.model;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Authorities extends DataEntity {
 
-	public Authorities(int keyLong, String username, String authority, String lastUser, Timestamp lastDate, int lastAction) {
+	public Authorities(int keyLong, String username, String authority, String lastUser, LocalDateTime lastDate, int lastAction) {
 
 		this.username = username;
 		this.authority = authority;

--- a/service/src/main/java/aero/minova/cas/service/model/DataEntity.java
+++ b/service/src/main/java/aero/minova/cas/service/model/DataEntity.java
@@ -1,7 +1,6 @@
 package aero.minova.cas.service.model;
 
-import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -20,21 +19,19 @@ public abstract class DataEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "KeyLong")
 	private Integer keyLong;
 
 	@NotNull
 	@Size(max = 200)
-	@Column(name = "KeyText", length = 200)
+	@Column(length = 200)
 	public String keyText;
 
-	@Column(name = "LastAction")
 	private Integer lastAction = 1;
 
 	@Size(max = 50)
-	@Column(name = "LastUser", length = 50)
+	@Column(length = 50)
 	String lastUser = BaseService.getCurrentUser();
 
-	@Column(name = "LastDate")
-	public Timestamp lastDate = Timestamp.from(Instant.now());
+	@Column(columnDefinition = "TIMESTAMP")
+	public LocalDateTime lastDate = LocalDateTime.now();
 }

--- a/service/src/main/java/aero/minova/cas/service/model/Error.java
+++ b/service/src/main/java/aero/minova/cas/service/model/Error.java
@@ -1,7 +1,6 @@
 package aero.minova.cas.service.model;
 
-import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -36,7 +35,7 @@ public class Error {
 	public String errormessage;
 
 	@NotNull
-	@Column(name = "Date")
-	public Timestamp lastdate = Timestamp.from(Instant.now());
+	@Column(name = "Date", columnDefinition = "TIMESTAMP")
+	public LocalDateTime lastdate = LocalDateTime.now();
 
 }

--- a/service/src/main/java/aero/minova/cas/service/model/ServiceMessage.java
+++ b/service/src/main/java/aero/minova/cas/service/model/ServiceMessage.java
@@ -1,6 +1,6 @@
 package aero.minova.cas.service.model;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotNull;
 
@@ -36,8 +36,8 @@ public class ServiceMessage extends DataEntity {
 	public int numberOfAttempts = 0;
 
 	@NotNull
-	@Column(name = "MessageCreationDate")
-	public Timestamp messageCreationDate;
+	@Column(name = "MessageCreationDate", columnDefinition = "TIMESTAMP")
+	public LocalDateTime messageCreationDate;
 
 	@NotNull
 	@Column(name = "Failed")

--- a/service/src/test/java/aero/minova/cas/service/ViewServiceBaseTest.java
+++ b/service/src/test/java/aero/minova/cas/service/ViewServiceBaseTest.java
@@ -65,11 +65,11 @@ public abstract class ViewServiceBaseTest<T extends ViewServiceInterface> extend
 		authorizationService.createOrUpdateAdminUser("admin", "$2a$10$l6uLtEVvQAOI7hOXutd7Ye0FtlaL7/npwGu/8YN31EhkHT0wjdtIq");
 
 		// Ein paar Daten erstellen
-		authoritiesRepository.save(new Authorities(1, "User1", "test", "user", Timestamp.valueOf("2023-06-18 00:00:00.0"), 1));
-		authoritiesRepository.save(new Authorities(2, "User2", "TEST", "user", Timestamp.valueOf("2023-06-19 00:00:00.0"), 2));
-		authoritiesRepository.save(new Authorities(3, "User3", "not test", "user", Timestamp.valueOf("2023-06-19 08:00:00.0"), 1));
-		authoritiesRepository.save(new Authorities(4, "User4", "testtest", "user", Timestamp.valueOf("2023-06-19 16:00:00.0"), 1));
-		authoritiesRepository.save(new Authorities(5, "User5", "te", null, Timestamp.valueOf("2023-06-20 08:00:00.0"), -1));
+		authoritiesRepository.save(new Authorities(1, "User1", "test", "user", Timestamp.valueOf("2023-06-18 00:00:00.0").toLocalDateTime(), 1));
+		authoritiesRepository.save(new Authorities(2, "User2", "TEST", "user", Timestamp.valueOf("2023-06-19 00:00:00.0").toLocalDateTime(), 2));
+		authoritiesRepository.save(new Authorities(3, "User3", "not test", "user", Timestamp.valueOf("2023-06-19 08:00:00.0").toLocalDateTime(), 1));
+		authoritiesRepository.save(new Authorities(4, "User4", "testtest", "user", Timestamp.valueOf("2023-06-19 16:00:00.0").toLocalDateTime(), 1));
+		authoritiesRepository.save(new Authorities(5, "User5", "te", null, Timestamp.valueOf("2023-06-20 08:00:00.0").toLocalDateTime(), -1));
 	}
 
 	@Test


### PR DESCRIPTION
* LocalDateTime statt Timestamp in Entities verwenden
* Bei Index-Anfragen auch LastAction >0 filtern