### PR TITLE
Konfigurierte Bezeichnung des CAS über GET /label abrufbar machen

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@ Alle wesentlichen Änderungen für dieses Projekt werden hier dokumentiert.
 Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog].
 
 ## Unreleased
+* Konfigurierte Bezeichnung des CAS über GET /label abrufbar machen
 
 ## [13.2.2] — 2024-04-08
 * Modelklassen-Attribute einheitlich auf private

--- a/service/doc/adoc/properties.adoc
+++ b/service/doc/adoc/properties.adoc
@@ -113,6 +113,14 @@ ob eingehende Anfragen auf Dateien auf Berechtigung überprüft werden sollen.
 
 ** *Wertebereich*: URLs mit Kommata getrennt, zur Festlegung erlaubter Origins für CORS.
 
+
+* aero.minova.cas.label
+
+** *Default*: nicht gesetzt
+
+** *Beschreibung*: Bezeichnung für das CAS. Wird vom WFC angefragt und im Hauptfenster angezeigt
+
+
 == Profiles
 
 * spring.profiles.active

--- a/service/src/main/java/aero/minova/cas/controller/CommunicationController.java
+++ b/service/src/main/java/aero/minova/cas/controller/CommunicationController.java
@@ -21,6 +21,9 @@ public class CommunicationController {
 	@Value("${server.servlet.context-path:}")
 	String homePath;
 
+	@Value("${aero.minova.cas.label:}")
+	String label;
+
 	@Autowired
 	SqlProcedureController spc;
 
@@ -78,5 +81,14 @@ public class CommunicationController {
 			httpServletResponse.setHeader("Location", homePath + "/setupError");
 			httpServletResponse.setStatus(302);
 		}
+	}
+
+	/**
+	 * Hiermit kann die konfigurierte Bezeichnung des CAS abgerufen werden
+	 */
+	@GetMapping(value = "label", produces = "application/json")
+	public String getLabel() {
+		customLogger.logInfo("Received request for CAS Label");
+		return label;
 	}
 }


### PR DESCRIPTION
Wird im WFC angezeigt:
https://github.com/minova-afis/aero.minova.rcp/pull/1577

Für https://github.com/minova-afis/com.minova.oiltanking.twb/issues/1690