### PR TITLE
Maske LDAP User: Mehr Zeichen für KeyText erlauben

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,8 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 
 ## Unreleased
 
+* Maske LDAP User: Mehr Zeichen für KeyText erlauben
+
 ## [13.5.3/4] — 2025-01-14
 * ErrorMessage Spalte in der Datenbank auf Länge von 2000 Zeichen erweitern
 * Setup nicht abbrechen, wenn das setup.xml File einer Abhängigkeit nicht gefunden wurde

--- a/app/src/main/app/forms/User.form.xml
+++ b/app/src/main/app/forms/User.form.xml
@@ -20,11 +20,11 @@
 			<field name="KeyLong" key-type="primary" sql-index="0" visible="false">
 				<number/>
 			</field>
-			<field name="KeyText" sql-index="1" text="@xtcasUser.KeyText" required="true" key-type="user">
-				<text length="10"/>
+			<field name="KeyText" sql-index="1" text="@xtcasUser.KeyText" required="true" key-type="user" fill="toright">
+				<text length="100"/>
 			</field>
 			<field name="UserSecurityToken" sql-index="2" text="@xtcasUser.UserSecurityToken" number-columns-spanned="4" required="true" fill="toright">
-				<text length="50"/>
+				<text length="100"/>
 			</field>
 			<field name="Memberships" sql-index="3" text="@xtcasUser.Memberships" number-columns-spanned="4" fill="toright">
 				<text length="250"/>


### PR DESCRIPTION
closes https://github.com/minova-afis/aero.minova.cas/issues/1201