### PR TITLE
add entry to changelog

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,8 @@ Das Format basiert auf link:https://keepachangelog.com/en/1.0.0[Keep a Changelog
 ## Unreleased
 
 * Maske LDAP User: Mehr Zeichen für KeyText erlauben
+* CORS Erweitern: `https://saas-app.minova.com,https://saas-app-dev.minova.com` Zugriff gewähren, damit SAM PWA DEMO nicht mehr mit 403er Fehler abgewiesen wird. Mr. Katzenberger würde die PWA gerne vorstellen.
+
 
 ## [13.5.3/4] — 2025-01-14
 * ErrorMessage Spalte in der Datenbank auf Länge von 2000 Zeichen erweitern


### PR DESCRIPTION
Die beiden URIS `https://saas-app.minova.com` und `https://saas-app-dev.minova.com` habe ich versehentlich bereits auf `main` gepusht statt in diesen Branch:
https://github.com/minova-afis/aero.minova.cas/blob/main/service/src/main/java/aero/minova/cas/SecurityConfig.java


Die Änderung ist nötig, weil @ulf65 bei der Präsentation der SAM PWA folgenden 403-Fehler wegen CORS bekommen wird:
<img width="1007" alt="Bildschirmfoto 2025-03-07 um 11 48 13" src="https://github.com/user-attachments/assets/b4522382-af74-4bbd-9e32-f4092e00f5cf" />