### PR TITLE
Allow localhost:3000 in mcas cors

### DIFF
--- a/mcas/src/main/resources/application.properties
+++ b/mcas/src/main/resources/application.properties
@@ -51,7 +51,7 @@ login_dataSource=database
 #### Server Configuration ####
 server.servlet.context-path=/
 server.port=8084
-cors.allowed.origins=https://ng-dev.minova.com,https://ng.minova.com,http://localhost,https://editor.swagger.io/
+cors.allowed.origins=https://ng-dev.minova.com,https://ng.minova.com,http://localhost,http://localhost:3000,https://editor.swagger.io/
 
 #### Management/Monitoring ####
 management.server.port=8081

--- a/mcas/src/main/resources/setup/Setup.xml
+++ b/mcas/src/main/resources/setup/Setup.xml
@@ -50,7 +50,7 @@
 				<!-- #### Server Configuration #### -->
 				<entry key="server.servlet.context-path" value="/cas"/>
 				<entry key="server.port" value="8084"/>
-				<entry key="cors.allowed.origins" value="https://ng-dev.minova.com,https://ng.minova.com,http://localhost,https://editor.swagger.io/"/>
+				<entry key="cors.allowed.origins" value="https://ng-dev.minova.com,https://ng.minova.com,http://localhost,http://localhost:3000,https://editor.swagger.io/"/>
 				
 				<!-- #### Management/Monitoring #### -->
 				<entry key="management.server.port" value="8091"/>


### PR DESCRIPTION
# CORS für http://localhost:3000

Die [React GUI](https://github.com/minova-afis/ch.minova.gui.react) startet im Dev-Server per default auf Port 3000.

Es wäre gut wenn ohne extra Config http://localhost:3000 erlaubt wäre.