### PR TITLE
GH-15487 -  update - foundation.rest.db to 1.0.6

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>ch.minova</groupId>
             <artifactId>foundation.rest.db</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>ch.minova</groupId>
             <artifactId>foundation.rest.db</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
 Summary

  - Bumps ch.minova:foundation.rest.db from 1.0.4 → 1.0.5 in service/pom.xml

  What's in 1.0.5 (foundation.rest.db GH-7)

  - @Transactional on saveFile — fixes a UNIQUE constraint violation when re-uploading a file that was previously soft-deleted
  (detached entity caused INSERT instead of UPDATE)
  - PATCH /file/reactivate?path= — new endpoint to restore a soft-deleted file without changing its content
  - GET /file/list?includeInactive=true — new optional param to include soft-deleted entries in the listing (default false, fully
  backward compatible)

  Test plan

  - Upload a file, soft-delete it, re-upload the same path → no UNIQUE constraint error, file is reactivated
  - GET /file/list returns only active files by default
  - GET /file/list?includeInactive=true returns both active and inactive files
  - PATCH /file/reactivate?path=<key> sets active=true on a soft-deleted file