### PR TITLE
Fix AutoSetupService NPE from unordered QueueService init

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,8 +5,8 @@ on:
       - '**'
   workflow_dispatch:
 jobs:
-  Build:
-    uses: minova-afis/aero.minova.os.github.workflows/.github/workflows/java-continuous-integration.yml@main
+  Build: #Change the branch to which is pointint due to issues with sonarqube step. (After issue is resolved please move back)
+    uses: minova-afis/aero.minova.os.github.workflows/.github/workflows/java-continuous-integration.yml@hoj_java_21
     secrets: inherit
     with:
       dependency-check-goal: 'help'

--- a/service/src/main/java/aero/minova/cas/controller/SqlProcedureController.java
+++ b/service/src/main/java/aero/minova/cas/controller/SqlProcedureController.java
@@ -259,7 +259,9 @@ public class SqlProcedureController {
 			}
 
 			ResponseEntity result = new ResponseEntity(processSqlProcedureRequest(inputTable, privilegeRequest), HttpStatus.ACCEPTED);
-			queueService.accept(inputTable, result);
+			if (queueService != null) {
+				queueService.accept(inputTable, result);
+			}
 
 			return result;
 		} catch (Throwable e) {
@@ -284,7 +286,9 @@ public class SqlProcedureController {
 			if (extensions.containsKey(inputTable.getName())) {
 				final var extension = extensions.get(inputTable.getName());
 				extResult = extension.apply(inputTable);
-				queueService.accept(inputTable, extResult);
+				if (queueService != null) {
+					queueService.accept(inputTable, extResult);
+				}
 				if (extResult == null) {
 					customLogger.logError(
 							"Extension " + extension

--- a/service/src/main/java/aero/minova/cas/service/AutoSetupService.java
+++ b/service/src/main/java/aero/minova/cas/service/AutoSetupService.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -35,6 +36,13 @@ import jakarta.annotation.PostConstruct;
  */
 @Service
 @ConditionalOnProperty(name = "ng.api.autosetup", havingValue = "true", matchIfMissing = false)
+// SqlProcedureController.queueService is wired manually by QueueService's own @PostConstruct
+// (circular-dependency workaround, see SqlProcedureController#queueService). Without this,
+// Spring's component-scan order decides whether that wiring has happened before executeSetup()
+// below calls into SqlProcedureController, and that order isn't guaranteed — it was observed to
+// consistently NPE (this.queueService == null) under Jib-built container images while succeeding
+// locally. @DependsOn makes QueueService's initialization deterministic instead of order-dependent.
+@DependsOn("queueService")
 public class AutoSetupService {
 
 	@Autowired


### PR DESCRIPTION
 ## Summary
  - `AutoSetupService.autoSetup()` (the `ng.api.autosetup=true` bootstrap path) was crashing with `NullPointerException:
  this.queueService is null` before ever creating the admin user, blocking auto-setup entirely on a fresh database.
  - Root cause: `SqlProcedureController.queueService` is wired manually by `QueueService`'s own `@PostConstruct` (a workaround for
  their circular `@Autowired` dependency), not by Spring DI. Nothing declared that ordering dependency, so whether the wiring had
  happened before `AutoSetupService`'s own `@PostConstruct` needed it depended entirely on unguaranteed component-scan order.
  - Reproduced 100% of the time on the Jib-built container image (`ghcr.io/minova-afis/aero.minova.mcas:1.5.3` and `:1.5.4`), while
  succeeding consistently via local `java -jar` / `mvn spring-boot:run`. Leading theory: directory-enumeration order for Jib's
  exploded classpath (`/app/classes`) isn't stable the way a packaged jar's index is — but regardless of the exact trigger, the fix
  removes the ambiguity outright rather than relying on it landing the lucky way.
  - Impact: on a fresh DB, nothing can log in via `login_dataSource=database` afterward — the documented fallback (`POST /setup`)
  itself requires an already-authenticated privileged user, which doesn't exist yet.

  ## Fix
  - `AutoSetupService`: added `@DependsOn("queueService")` so Spring initializes `QueueService` (and its wiring into
  `SqlProcedureController`) before auto-setup runs, deterministically.
  - `SqlProcedureController`: null-guarded both `queueService.accept(...)` call sites (`executeProcedure`, `checkForExtension`) as
  defense in depth — a missing wiring now degrades to a skipped notification instead of crashing procedure execution.