### PR TITLE
GH-1491 -  update: foundation.rest.db to 1.1.4

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>ch.minova</groupId>
             <artifactId>foundation.rest.db</artifactId>
-            <version>1.0.6</version>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
  - Bumps `service/pom.xml`'s `foundation.rest.db` dependency from `1.0.6` to `1.1.4`.
  - Brings in two fixes from `foundation.rest.db` [GH-12](https://github.com/minova-afis/foundation.rest.db/issues/12):
    - `saveFile()` no longer nulls a file's `DefaultValue` when a custom `Value` is saved — previously
      every custom upload permanently destroyed the original default.
    - New `PATCH /file/revert?path=` endpoint to clear a file's custom value and fall back to
      `DefaultValue` again.
  ## Why
  web.ui's File Manager plugin needs both of these — a "rollback to default" action and (later) a
  default-vs-custom diff view — neither was possible before since the default was destroyed the
  moment a file got customized.