### PR TITLE
GH-1493: Bump foundation.rest.db dependency to 1.1.5

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>ch.minova</groupId>
             <artifactId>foundation.rest.db</artifactId>
-            <version>1.1.4</version>
+            <version>1.1.5</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
 ## Summary
  - Bumps `service/pom.xml`'s `foundation.rest.db` dependency from `1.1.4` to `1.1.5`.
  - Brings in `GH-14`'s addition: a `variant` query param on `GET /file` (`variant=default` /
    `variant=value`), letting a caller fetch a file's default and custom content independently
    instead of only the merged/effective blob.

  ## Why
  web.ui's File Manager plugin is adding a default-vs-custom diff view (shown when a file has a
  custom value) — it needs both `GET /file?path=...&variant=default` and `...&variant=value` to
  populate the two columns, which requires mcas running `foundation.rest.db >= 1.1.5`.